### PR TITLE
fix: GitHub公式のPages Actionに変更してデプロイメント権限エラーを解決

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,34 +5,53 @@ on:
     branches:
       - main
 
-# 権限を明示的に設定
+# GitHub Pages用の権限設定
 permissions:
   contents: read
   pages: write
   id-token: write
 
+# 同時実行を防ぐ
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  deploy:
+  # Build job
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-
+        uses: actions/checkout@v4
+      
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'npm'
-
+      
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      
       - name: Install dependencies
         run: npm ci
-
+      
       - name: Build
         run: npm run build
-
-      - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4
+      
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          folder: build
-          branch: gh-pages
-          token: ${{ secrets.GITHUB_TOKEN }}
+          path: ./build
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- JamesIves/github-pages-deploy-actionからGitHub公式のactions/deploy-pages@v4に変更
- ビルドとデプロイを分離した2段階ジョブ構成に変更
- GitHub Pages環境での実行を明示的に設定
- 同時実行制御を追加してデプロイメントの競合状態を防止
- Actions v4系に統一してより安定した実行環境を構築

これによりGitHub Pagesの権限システムとの完全な互換性を確保